### PR TITLE
Elixir・Erlang・Nodeのバージョンを上げる

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,12 @@
 
 ## バージョン
 
-- Elixir 1.11.0 (compiled with Erlang/OTP 22)
-- phx_new-1.5.6
-- node v12.16.1
+- Elixir 1.11.2 (compiled with Erlang/OTP 22)
 
----
+  - Erlang 22.3.4.9
 
-# SampleApp
+  - phx_new-1.5.6
 
-To start your Phoenix server:
+- node v14.15.3
 
-  * Install dependencies with `mix deps.get`
-  * Install Node.js dependencies with `npm install` inside the `assets` directory
-  * Start Phoenix endpoint with `mix phx.server`
-
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
-
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+  - npm 6.14.9

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,7 +14,8 @@ config :sample_app, SampleAppWeb.Endpoint,
   url: [scheme: "https", host: "local-playground-no-ecto.herokuapp.com", port: 443],
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/cache_manifest.json"
-  # secret_key_base: System.get_env("SECRET_KEY_BASE")
+
+# secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
-erlang_version=22.0.3
-elixir_version=1.11.0
+erlang_version=22.3.4.9
+elixir_version=1.11.2
 
 always_rebuild=true

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,4 +1,4 @@
-node_version=12.16.1
-npm_version=6.14.8
+node_version=14.15.3
+npm_version=6.14.9
 assets_path=.
 phoenix_ex=phx


### PR DESCRIPTION
旧
- Elixir 1.11.0 (compiled with Erlang/OTP 22)
- node v12.16.1

新
- Elixir 1.12.2（最新）
- Erlang 22系の最新
- Nodejs 14系の最新

closed: https://github.com/miolab/phoenix_local_playground_no_ecto/issues/13