### PR TITLE
Phoenix 1.5.7バージョンを明示的にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
   - Erlang 22.3.4.9
 
-  - phx_new-1.5.6
+  - Phoenix 1.5.7
 
 - node v14.15.3
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule SampleApp.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:phoenix, "~> 1.5.6"},
+      {:phoenix, "~> 1.5.7"},
       {:phoenix_html, "~> 2.11"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:phoenix_live_dashboard, "~> 0.3 or ~> 0.2.9"},


### PR DESCRIPTION
すでに1.5.7ではあったが、明示的にしてなかったので
（1.5.6のままになっていた）